### PR TITLE
Arkiv simulator støtter oppdater mappe meldinger og "statiske" arkivmeldinger

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # fiks-arkiv
 
 ## Hva er dette?
-Dette repositoriet inneholder dokumentasjon, eksempler og brukerhistorier for **fiks-arkiv**, samt applikasjonene **arkivsystem.sample** og **fagsystem.arkiv.sample** som er kjørbare eksempler på implementasjon av FIKS IO integrasjon..
+Dette repositoriet inneholder dokumentasjon, eksempler og brukerhistorier for **fiks-arkiv**, samt applikasjonene **Arkiv simulator** (arkivsystem.sample) og **Fagsystem simulator** (fagsystem.arkiv.sample) som er kjørbare eksempler på implementasjon av Fiks-Arkiv protokollen med Fiks-IO integrasjon.
 
 Se [README.md](dotnet-source/README.md) under dotnet-source for mer informasjon om eksempel applikasjonene og dette arbeidet.
 
@@ -11,25 +11,37 @@ Se i mappen [**eksempel**](eksempel) for eksempler på meldinger.
 
 ## Applikasjonene
 
-Applikasjonen **arkivsystem.sample** kjører i test og tar i mot meldinger og svarer med faste meldinger tilbake.
-Den brukes i test sammen med **fiks-protokoll-validator**. 
-
-Applikasjonen **fagsystem.arkiv** kjører ikke i noen miljøer da den sender noen faste meldinger ved oppstart.
-
-
 Applikasjonene er console applikasjoner som kjører i bakgrunnen eller man kan kjøre de vha docker-compose.
 
-Nuget biblioteket **KS.Fiks.IO.Arkivintegrasjon.Client** som brukes er tilgjengelig på Github [her.](https://github.com/ks-no/fiks-arkiv) 
+Nuget biblioteket som inneholder modeller og xsd'er for Fiks-Arkiv, **KS.Fiks.Arkiv.Models.V1** som brukes er tilgjengelig på Github [her.](https://www.nuget.org/packages/KS.Fiks.Arkiv.Models.V1/)
+
+
+### Arkiv simulator (ks.fiks.io.arkivsystem.sample)
+Applikasjonen **arkivsystem.sample** er en "Arkiv simulator" som kjører i dev og test og tar i mot meldinger og svarer med faste meldinger tilbake.
+Den cacher arkivmeldinger også for at man skal kunne først "arkivere" f.eks. en journalpost og så oppdatere den etterpå ved en oppdater-melding. 
+Caching blir gjort når en melding kommer inn med Fiks-IO headeren 'testSessionId'. 
+Følgende meldinger som bruker samme header vil da sjekke i cache og f.eks. oppdatere eller hente data fra cache. 
+Dette blir brukt av både Fiks-protokoll-validator og integrasjonstester.
+
+Github Fiks-protokoll-validator [her.](https://github.com/ks-no/fiks-protokoll-validator)
+
+Github Fiks-arkiv-integrasjonstester [her.](https://github.com/ks-no/fiks-arkiv-integration-tests-dotnet)
+
+
+### Fagsystem simulator (ks.fiks.io.fagsystem.arkiv.sample)
+Applikasjonen **fagsystem.arkiv** kjører ikke i noen miljøer da den sender noen faste meldinger ved oppstart.
 
 ### Testing i Development miljø
-Man kan kjøre testene i testmiljøet for fiks-protokoll-validator [her.](https://forvaltning.fiks.dev.ks.no/fiks-validator/#/)
+
+
+Man kan kjøre testene i testmiljøet for *Fiks-protokoll-validator* [her.](https://forvaltning.fiks.dev.ks.no/fiks-validator/#/)
 
 Konto id man kan benytte:
 - Arkivsystem: 760fd7d6-435f-4c1b-97d5-92fbe2f603b0
 - Fagsystem arkiv: 4a416cde-2aca-4eef-bec4-efddcee0fcea
 
 ### Testing i Test miljø
-Man kan kjøre testene i Fiks-protokoll-validator [her.](https://forvaltning.fiks.test.ks.no/fiks-validator/#/)
+Man kan kjøre testene i *Fiks-protokoll-validator* [her.](https://forvaltning.fiks.test.ks.no/fiks-validator/#/)
 
 Konto id man kan benytte:
 - Arkivsystem: 8752e128-0e2b-494c-8fab-8e3577aca13d

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Se i mappen [**eksempel**](eksempel) for eksempler på meldinger.
 
 Applikasjonene er console applikasjoner som kjører i bakgrunnen eller man kan kjøre de vha docker-compose.
 
-Nuget biblioteket som inneholder modeller og xsd'er for Fiks-Arkiv, **KS.Fiks.Arkiv.Models.V1** som brukes er tilgjengelig på Github [her.](https://www.nuget.org/packages/KS.Fiks.Arkiv.Models.V1/)
+Nuget biblioteket som inneholder modeller og xsd'er for Fiks-Arkiv, **KS.Fiks.Arkiv.Models.V1** som brukes er tilgjengelig på NuGet [her.](https://www.nuget.org/packages/KS.Fiks.Arkiv.Models.V1/)
 
 
 ### Arkiv simulator (ks.fiks.io.arkivsystem.sample)

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/ArkivSimulator.cs
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/ArkivSimulator.cs
@@ -28,6 +28,7 @@ namespace ks.fiks.io.arkivsystem.sample
         private static readonly ILogger Log = Serilog.Log.ForContext(MethodBase.GetCurrentMethod()?.DeclaringType);
         public static SizedDictionary<string, Arkivmelding> _arkivmeldingCache;
         private JournalpostHentHandler _journalpostHentHandler;
+        private MappeHentHandler _mappeHentHandler;
         private SokHandler _sokHandler;
         private ArkivmeldingHandler _arkivmeldingHandler;
         private ArkivmeldingOppdaterHandler _arkivmeldingOppdaterHandler;
@@ -39,6 +40,7 @@ namespace ks.fiks.io.arkivsystem.sample
             client = FiksIOClientBuilder.CreateFiksIoClient(appSettings);
             _arkivmeldingCache = new SizedDictionary<string, Arkivmelding>(100);
             _journalpostHentHandler = new JournalpostHentHandler();
+            _mappeHentHandler = new MappeHentHandler();
             _sokHandler = new SokHandler();
             _arkivmeldingHandler = new ArkivmeldingHandler();
             _arkivmeldingOppdaterHandler = new ArkivmeldingOppdaterHandler();
@@ -86,6 +88,7 @@ namespace ks.fiks.io.arkivsystem.sample
             {
                 FiksArkivV1Meldingtype.Sok => _sokHandler.HandleMelding(mottatt),
                 FiksArkivV1Meldingtype.JournalpostHent => _journalpostHentHandler.HandleMelding(mottatt),
+                FiksArkivV1Meldingtype.MappeHent => _mappeHentHandler.HandleMelding(mottatt),
                 _ => throw new ArgumentException("Case not handled")
             };
 

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/ArkivSimulator.cs
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/ArkivSimulator.cs
@@ -53,9 +53,12 @@ namespace ks.fiks.io.arkivsystem.sample
             InitArkivmeldingStorage();
         }
 
+        /*
+         * Fyller opp _arkivmeldingProtokollValidatorStorage med arkivmeldinger som validator trenger for å kunne svare på enkeltstående requests
+         * som hent- og oppdater-meldinger
+         */
         private void InitArkivmeldingStorage()
         {
-       
             var serializer = new XmlSerializer(typeof(Arkivmelding));
             var xml = File.ReadAllText("Xml/OppdaterMappeSaksansvarligN1/arkivmelding.xml", Encoding.UTF8);
             Arkivmelding arkivmelding;

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/Generators/FeilmeldingGenerator.cs
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/Generators/FeilmeldingGenerator.cs
@@ -31,5 +31,15 @@ namespace ks.fiks.io.arkivsystem.sample.Generators
                 CorrelationId = Guid.NewGuid().ToString()
             };
         }
+        
+        public static ServerFeil CreateServerFeilMelding(string feilmelding)
+        {
+            return new ServerFeil()
+            {
+                ErrorId = Guid.NewGuid().ToString(),
+                Feilmelding = feilmelding,
+                CorrelationId = Guid.NewGuid().ToString()
+            };
+        }
     }
 }

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/Generators/JournalpostHentGenerator.cs
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/Generators/JournalpostHentGenerator.cs
@@ -1,6 +1,7 @@
 using System;
 using KS.Fiks.Arkiv.Models.V1.Arkivstruktur;
 using KS.Fiks.Arkiv.Models.V1.Innsyn.Hent.Journalpost;
+using KS.Fiks.Arkiv.Models.V1.Kodelister;
 using KS.Fiks.Arkiv.Models.V1.Metadatakatalog;
 
 namespace ks.fiks.io.arkivsystem.sample.Generators
@@ -16,6 +17,7 @@ namespace ks.fiks.io.arkivsystem.sample.Generators
         private const string DokumentobjektSjekksumDefault = "foo";
         private const string DokumentobjektSjekksumAlgoritmeDefault = "MD5";
         private const string DokumentobjektFilstoerrelseDefault = "100";
+        private const string SaksbehandlerKorrespondansepartDefault = "Ingrid Mottaker";
 
         public static JournalpostHentResultat Create(JournalpostHent journalpostHent)
         {
@@ -43,10 +45,11 @@ namespace ks.fiks.io.arkivsystem.sample.Generators
             };
         }
         
-        public static Journalpost CreateHentJournalpostArkivmeldingJournalpost (KS.Fiks.Arkiv.Models.V1.Arkivering.Arkivmelding.Journalpost arkivmeldingJournalpost)
+        public static Journalpost CreateHentJournalpostFraArkivmeldingJournalpost (KS.Fiks.Arkiv.Models.V1.Arkivering.Arkivmelding.Journalpost arkivmeldingJournalpost)
         {
             var jp = new Journalpost()
             {
+                SystemID = arkivmeldingJournalpost.SystemID ?? new SystemID() { Value = Guid.NewGuid().ToString() }, 
                 OpprettetAv = arkivmeldingJournalpost.OpprettetAv,
                 ArkivertAv = arkivmeldingJournalpost.ArkivertAv,
                 ReferanseForelderMappe = new SystemID() { Label = arkivmeldingJournalpost.ReferanseForelderMappe.Label, Value = arkivmeldingJournalpost.ReferanseForelderMappe.Value },
@@ -57,8 +60,8 @@ namespace ks.fiks.io.arkivsystem.sample.Generators
                 },
                 Tittel = arkivmeldingJournalpost.Tittel,
                 Journalaar = DateTime.Now.Year.ToString(),
-                Journalsekvensnummer = arkivmeldingJournalpost.Journalsekvensnummer ?? JournalsekvensnummerDefault, //Setter denne til noe unikt via DateTime.Now
-                Journalpostnummer = arkivmeldingJournalpost.Journalpostnummer ?? JournalpostnummerDefault,
+                Journalsekvensnummer = arkivmeldingJournalpost.Journalsekvensnummer ?? JournalsekvensnummerDefault,
+                Journalpostnummer = arkivmeldingJournalpost.Journalpostnummer ?? DateTime.Now.Year + DateTime.Now.Millisecond.ToString(),
                 Journalposttype = new Journalposttype()
                 {
                     KodeProperty = arkivmeldingJournalpost.Journalposttype.KodeProperty
@@ -90,6 +93,7 @@ namespace ks.fiks.io.arkivsystem.sample.Generators
             {
                 var nyDokumentbeskrivelse = new Dokumentbeskrivelse()
                 {
+                    SystemID = dokumentbeskrivelse.SystemID ?? new SystemID() { Value = Guid.NewGuid().ToString() },
                     Dokumenttype = new Dokumenttype()
                     {
                         KodeProperty = dokumentbeskrivelse.Dokumenttype.KodeProperty
@@ -136,21 +140,8 @@ namespace ks.fiks.io.arkivsystem.sample.Generators
                         Filstoerrelse = dokumentobjekt.Filstoerrelse ?? DokumentobjektFilstoerrelseDefault
                     });
                 }
-                // Den må få en SystemID som er påkrevd
-                nyDokumentbeskrivelse.SystemID = new SystemID()
-                {
-                    Value = Guid.NewGuid().ToString()
-                };
-                
                 jp.Dokumentbeskrivelse.Add(nyDokumentbeskrivelse);
             }
-
-            // Den må få en SystemID som er påkrevd
-            jp.SystemID = new SystemID()
-            {
-                Value = Guid.NewGuid().ToString()
-            };
-            
             return jp;
         }
 
@@ -158,6 +149,7 @@ namespace ks.fiks.io.arkivsystem.sample.Generators
         {
             return new Journalpost()
             {
+                SystemID = new SystemID() { Value = Guid.NewGuid().ToString() },
                 OpprettetAv = "En brukerid",
                 ArkivertAv = "En brukerid",
                 ReferanseForelderMappe = new SystemID() { Label = "", Value = Guid.NewGuid().ToString() },
@@ -170,6 +162,7 @@ namespace ks.fiks.io.arkivsystem.sample.Generators
                 {
                     new Dokumentbeskrivelse()
                     {
+                        SystemID = new SystemID() { Value = Guid.NewGuid().ToString() },
                         Dokumenttype = new Dokumenttype()
                         {
                             KodeProperty= "SØKNAD"
@@ -178,26 +171,37 @@ namespace ks.fiks.io.arkivsystem.sample.Generators
                         {
                             KodeProperty= "F"
                         },
+                        Dokumentnummer = "1",
+                        TilknyttetDato = new DateTime(),
+                        TilknyttetAv = DokumentbeskrivelseTilknyttetAvDefault,
                         Tittel = "Rekvisisjon av oppmålingsforretning",
                         TilknyttetRegistreringSom = new TilknyttetRegistreringSom()
                         {
                             KodeProperty= "H"
                         },
+                        OpprettetDato = DateTime.Now,
+                        OpprettetAv = DokumentbeskrivelseOpprettetAvDefault,
                         Dokumentobjekt =
                         {
                             new Dokumentobjekt()
                             {
+                                SystemID = new SystemID() { Value = Guid.NewGuid().ToString() },
                                 Versjonsnummer = "1",
                                 Variantformat = new Variantformat()
                                 {
-                                    KodeProperty= "P"
+                                    KodeProperty = VariantformatKoder.Arkivformat.Verdi
                                 },
                                 Format = new Format()
                                 {
-                                    KodeProperty= "PDF"
+                                    KodeProperty = FormatKoder.PDFA.Verdi
                                 },
-                                Filnavn = "rekvisjon.pdf",
-                                ReferanseDokumentfil = "rekvisisjon.pdf"
+                                Filnavn = "Test.pdf",
+                                OpprettetDato = DateTime.Now,
+                                OpprettetAv = DokumentobjektOpprettetAvDefault,
+                                ReferanseDokumentfil = "test.pdf",
+                                Sjekksum = DokumentobjektSjekksumDefault,
+                                SjekksumAlgoritme = DokumentobjektSjekksumAlgoritmeDefault,
+                                Filstoerrelse = DokumentobjektFilstoerrelseDefault
                             }
                         }
                     }
@@ -213,9 +217,12 @@ namespace ks.fiks.io.arkivsystem.sample.Generators
                         },
                         KorrespondansepartNavn = "Oppmålingsetaten",
                         AdministrativEnhet = "Oppmålingsetaten",
-                        Saksbehandler = "Ingrid Mottaker"
+                        Saksbehandler = SaksbehandlerKorrespondansepartDefault
                     }
                 },
+                Journalaar = DateTime.Now.Year.ToString(),
+                Journalsekvensnummer = "1",
+                Journalpostnummer = DateTime.Now.Year + DateTime.Now.Millisecond.ToString(),
                 Journalposttype = new Journalposttype()
                 {
                     KodeProperty= "X"

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/Generators/JournalpostHentGenerator.cs
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/Generators/JournalpostHentGenerator.cs
@@ -9,6 +9,7 @@ namespace ks.fiks.io.arkivsystem.sample.Generators
     {
         private const string DokumentbeskrivelseOpprettetAvDefault = "Foo";
         private const string JournalpostnummerDefault = "1";
+        private const string JournalsekvensnummerDefault = "1";
         private const string DokumentbeskrivelseDokumentnummerDefault = "1";
         private const string DokumentbeskrivelseTilknyttetAvDefault = "foo";
         private const string DokumentobjektOpprettetAvDefault = "foo";
@@ -56,7 +57,7 @@ namespace ks.fiks.io.arkivsystem.sample.Generators
                 },
                 Tittel = arkivmeldingJournalpost.Tittel,
                 Journalaar = DateTime.Now.Year.ToString(),
-                Journalsekvensnummer = arkivmeldingJournalpost.Journalsekvensnummer ?? DateTime.Now.ToString(), //Setter denne til noe unikt via DateTime.Now
+                Journalsekvensnummer = arkivmeldingJournalpost.Journalsekvensnummer ?? JournalsekvensnummerDefault, //Setter denne til noe unikt via DateTime.Now
                 Journalpostnummer = arkivmeldingJournalpost.Journalpostnummer ?? JournalpostnummerDefault,
                 Journalposttype = new Journalposttype()
                 {
@@ -152,7 +153,7 @@ namespace ks.fiks.io.arkivsystem.sample.Generators
             
             return jp;
         }
-        
+
         public static Journalpost CreateJournalpost()
         {
             return new Journalpost()

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/Generators/MappeHentGenerator.cs
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/Generators/MappeHentGenerator.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Linq;
+using KS.Fiks.Arkiv.Models.V1.Arkivering.Arkivmelding;
+using KS.Fiks.Arkiv.Models.V1.Innsyn.Hent.Mappe;
+using KS.Fiks.Arkiv.Models.V1.Kodelister;
+using KS.Fiks.Arkiv.Models.V1.Metadatakatalog;
+
+namespace ks.fiks.io.arkivsystem.sample.Generators
+{
+    public class MappeHentGenerator
+    {
+        public static MappeHentResultat Create(MappeHent mappeHent)
+        {
+            return new MappeHentResultat()
+            {
+                Mappe = CreateMappe(mappeHent)
+            };
+        }
+        
+        public static MappeHentResultat CreateFromCache(MappeHent mappeHent, Arkivmelding arkivmeldingFraCache)
+        {
+            var arkivmeldingMappe = arkivmeldingFraCache.Mappe.FirstOrDefault(mappeFraCache => AreEqual(mappeHent, mappeFraCache));
+            KS.Fiks.Arkiv.Models.V1.Arkivstruktur.Mappe returnMappe;
+            
+            if (arkivmeldingMappe is Saksmappe mappe)
+            {
+                returnMappe = MapFromArkivmeldingMappe(mappe);
+            }
+            else
+            {
+                returnMappe = MapFromArkivmeldingMappe(arkivmeldingMappe);
+            }
+            return new MappeHentResultat
+            {
+                Mappe = returnMappe
+            };
+        }
+
+        private static bool AreEqual(MappeHent mappeHent, Mappe mappeFraCache)
+        {
+            if (mappeHent.ReferanseEksternNoekkel != null && mappeFraCache.ReferanseEksternNoekkel != null &&
+                mappeHent.ReferanseEksternNoekkel.Noekkel == mappeFraCache.ReferanseEksternNoekkel.Noekkel)
+            {
+                return true;
+            }
+
+            return mappeHent.SystemID != null && mappeFraCache.SystemID != null && mappeHent.SystemID == mappeFraCache.SystemID;
+        }
+
+        public static KS.Fiks.Arkiv.Models.V1.Arkivstruktur.Mappe CreateMappe(MappeHent mappeHent)
+        {
+            return new KS.Fiks.Arkiv.Models.V1.Arkivstruktur.Mappe()
+            {
+                
+            };
+        }
+
+        public static KS.Fiks.Arkiv.Models.V1.Arkivstruktur.Mappe MapFromArkivmeldingMappe(Mappe arkivmeldingMappe)
+        {
+            var mappe = new KS.Fiks.Arkiv.Models.V1.Arkivstruktur.Mappe()
+            {
+                SystemID = arkivmeldingMappe.SystemID ?? new SystemID()
+                {
+                    Value = Guid.NewGuid().ToString()
+                },
+                MappeID = arkivmeldingMappe.MappeID ?? Guid.NewGuid().ToString(),
+                Tittel = arkivmeldingMappe.Tittel,
+                OffentligTittel = arkivmeldingMappe.OffentligTittel,
+                Beskrivelse = arkivmeldingMappe.Beskrivelse,
+                Skjerming = arkivmeldingMappe.Skjerming,
+                Gradering = arkivmeldingMappe.Gradering,
+                AvsluttetAv = arkivmeldingMappe.AvsluttetAv ?? "Avsluttet Av",
+                AvsluttetDato = arkivmeldingMappe.AvsluttetDato,
+                OpprettetAv = arkivmeldingMappe.OpprettetAv ?? "Opprettet Av",
+                OpprettetDato = arkivmeldingMappe.OpprettetDato
+                //Kassasjon = arkivmeldingMappe //TODO mangler i arkivstruktur
+            };
+            if (arkivmeldingMappe.Dokumentmedium != null)
+            {
+                mappe.Dokumentmedium = new Dokumentmedium()
+                {
+                    Beskrivelse = arkivmeldingMappe.Dokumentmedium.Beskrivelse,
+                    KodeProperty = arkivmeldingMappe.Dokumentmedium.KodeProperty
+                };
+            }
+
+            return mappe;
+        }
+        
+        public static KS.Fiks.Arkiv.Models.V1.Arkivstruktur.Saksmappe MapFromArkivmeldingMappe(Saksmappe arkivmeldingMappe)
+        {
+            var mappe = new KS.Fiks.Arkiv.Models.V1.Arkivstruktur.Saksmappe()
+            {
+                SystemID = arkivmeldingMappe.SystemID ?? new SystemID()
+                {
+                    Value = Guid.NewGuid().ToString()
+                },
+                MappeID = arkivmeldingMappe.MappeID ?? Guid.NewGuid().ToString(),
+                Tittel = arkivmeldingMappe.Tittel,
+                OffentligTittel = arkivmeldingMappe.OffentligTittel,
+                Beskrivelse = arkivmeldingMappe.Beskrivelse,
+                Skjerming = arkivmeldingMappe.Skjerming,
+                Gradering = arkivmeldingMappe.Gradering,
+                AvsluttetAv = arkivmeldingMappe.AvsluttetAv ?? "Avsluttet Av",
+                AvsluttetDato = arkivmeldingMappe.AvsluttetDato,
+                OpprettetAv = arkivmeldingMappe.OpprettetAv ?? "Opprettet Av",
+                OpprettetDato = arkivmeldingMappe.OpprettetDato,
+                //Kassasjon = arkivmeldingMappe //TODO mangler i arkivstruktur
+                Saksaar = arkivmeldingMappe.Saksaar ?? DateTime.Now.Year.ToString(),
+                Saksdato = arkivmeldingMappe.Saksdato,
+                Sakssekvensnummer = arkivmeldingMappe.Sakssekvensnummer ?? "1",
+                AdministrativEnhet = arkivmeldingMappe.AdministrativEnhet ?? "Administrativ enhet",
+                Saksansvarlig = arkivmeldingMappe.Saksansvarlig ?? "Default Saksansvarlig",
+                
+            };
+
+            if (arkivmeldingMappe.Saksstatus != null)
+            {
+                mappe.Saksstatus = new Saksstatus()
+                {
+                    Beskrivelse = arkivmeldingMappe.Saksstatus.Beskrivelse,
+                    KodeProperty = arkivmeldingMappe.Saksstatus.KodeProperty
+                };
+            }
+            else
+            {
+                mappe.Saksstatus = new Saksstatus()
+                {
+                    Beskrivelse = SaksstatusKoder.UnderBehandling.Beskrivelse,
+                    KodeProperty = SaksstatusKoder.UnderBehandling.Verdi
+                };
+            }
+            
+            
+            if (arkivmeldingMappe.Dokumentmedium != null)
+            {
+                mappe.Dokumentmedium = new Dokumentmedium()
+                {
+                    Beskrivelse = arkivmeldingMappe.Dokumentmedium.Beskrivelse,
+                    KodeProperty = arkivmeldingMappe.Dokumentmedium.KodeProperty
+                };
+            }
+
+            return mappe;
+        }
+    }
+}

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/Generators/SokGenerator.cs
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/Generators/SokGenerator.cs
@@ -14,28 +14,28 @@ namespace ks.fiks.io.arkivsystem.sample.Generators
                 ResponsType.Minimum =>
                     new Melding
                     {
-                        FileName = "sokeresultat-minimum.xml",
+                        FileName = "resultat.xml",
                         MeldingsType = FiksArkivV1Meldingtype.SokResultatMinimum,
                         ResultatMelding = SokeresultatGenerator.CreateSokeResultatMinimum(sok.Respons)
                     },
                 ResponsType.Noekler =>
                     new Melding
                     {
-                        FileName = "sokeresultat-noekler.xml",
+                        FileName = "resultat.xml",
                         MeldingsType = FiksArkivV1Meldingtype.SokResultatNoekler,
                         ResultatMelding = SokeresultatGenerator.CreateSokeResultatNoekler(),
                     },
                 ResponsType.Utvidet =>
                     new Melding
                     {
-                        FileName = "sokeresultat-utvidet.xml",
+                        FileName = "resultat.xml",
                         MeldingsType = FiksArkivV1Meldingtype.SokResultatUtvidet,
                         ResultatMelding = SokeresultatGenerator.CreateSokeResultatUtvidet(sok.Respons)
                     },
                 _ =>
                     new Melding
                     {
-                        FileName = "sokeresultat-minimum.xml",
+                        FileName = "resultat.xml",
                         MeldingsType = FiksArkivV1Meldingtype.SokResultatMinimum,
                         ResultatMelding = SokeresultatGenerator.CreateSokeResultatMinimum(sok.Respons),
                     }

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/Handlers/ArkivmeldingOppdaterHandler.cs
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/Handlers/ArkivmeldingOppdaterHandler.cs
@@ -62,9 +62,9 @@ namespace ks.fiks.io.arkivsystem.sample.Handlers
             {
                 ArkivSimulator._arkivmeldingCache.TryGetValue(testSessionId, out lagretArkivmelding);
             }
-            else if (ArkivSimulator._arkivmeldingProtokollValidatorStorage.ContainsKey(arkivmeldingOppdatering.MeldingId)) {
-                lagretArkivmelding =
-                    ArkivSimulator._arkivmeldingProtokollValidatorStorage[arkivmeldingOppdatering.MeldingId];
+            else if (mottatt.Melding.Headere.TryGetValue(ArkivSimulator.ValidatorTestNameHeader, out var testName)) 
+            {
+                ArkivSimulator._arkivmeldingProtokollValidatorStorage.TryGetValue(testName, out lagretArkivmelding);
             } 
         
             if(lagretArkivmelding != null) {

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/Handlers/ArkivmeldingOppdaterHandler.cs
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/Handlers/ArkivmeldingOppdaterHandler.cs
@@ -57,16 +57,8 @@ namespace ks.fiks.io.arkivsystem.sample.Handlers
                 MeldingsType = FiksArkivV1Meldingtype.ArkivmeldingMottatt,
             });
 
-            Arkivmelding lagretArkivmelding = null;
-            if (mottatt.Melding.Headere.TryGetValue(ArkivSimulator.TestSessionIdHeader, out var testSessionId))
-            {
-                ArkivSimulator._arkivmeldingCache.TryGetValue(testSessionId, out lagretArkivmelding);
-            }
-            else if (mottatt.Melding.Headere.TryGetValue(ArkivSimulator.ValidatorTestNameHeader, out var testName)) 
-            {
-                ArkivSimulator._arkivmeldingProtokollValidatorStorage.TryGetValue(testName, out lagretArkivmelding);
-            } 
-        
+            var lagretArkivmelding = TryGetLagretArkivmelding(mottatt);
+            
             if(lagretArkivmelding != null) {
                 try
                 {

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/Handlers/ArkivmeldingOppdaterHandler.cs
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/Handlers/ArkivmeldingOppdaterHandler.cs
@@ -50,28 +50,33 @@ namespace ks.fiks.io.arkivsystem.sample.Handlers
                 });
                 return meldinger;
             }
-            
+
             // Melding er validert i henhold til xsd, vi sender tilbake mottatt melding
             meldinger.Add(new Melding
             {
                 MeldingsType = FiksArkivV1Meldingtype.ArkivmeldingMottatt,
             });
 
+            Arkivmelding lagretArkivmelding = null;
             if (mottatt.Melding.Headere.TryGetValue(ArkivSimulator.TestSessionIdHeader, out var testSessionId))
             {
-                Arkivmelding lagretArkivmelding;
                 ArkivSimulator._arkivmeldingCache.TryGetValue(testSessionId, out lagretArkivmelding);
-
-                // Journalpost oppdatering?
+            }
+            else if (ArkivSimulator._arkivmeldingProtokollValidatorStorage.ContainsKey(arkivmeldingOppdatering.MeldingId)) {
+                lagretArkivmelding =
+                    ArkivSimulator._arkivmeldingProtokollValidatorStorage[arkivmeldingOppdatering.MeldingId];
+            } 
+        
+            if(lagretArkivmelding != null) {
                 try
                 {
                     if (arkivmeldingOppdatering.RegistreringOppdateringer.Count > 0)
                     {
-                        meldinger = OppdaterRegistreringer(arkivmeldingOppdatering, lagretArkivmelding);
+                        meldinger.AddRange(OppdaterRegistreringer(arkivmeldingOppdatering, lagretArkivmelding));
                     }
                     else if (arkivmeldingOppdatering.MappeOppdateringer.Count > 0) // Mappe oppdatering
                     {
-                        meldinger = OppdaterMapper(arkivmeldingOppdatering, lagretArkivmelding);
+                        meldinger.AddRange(OppdaterMapper(arkivmeldingOppdatering, lagretArkivmelding));
                     }
                 }
                 catch (Exception e)

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/Handlers/BaseHandler.cs
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/Handlers/BaseHandler.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reflection;
 using System.Xml;
 using System.Xml.Schema;
+using KS.Fiks.Arkiv.Models.V1.Arkivering.Arkivmelding;
 using KS.Fiks.ASiC_E;
 using KS.Fiks.IO.Client.Models;
 using Serilog;
@@ -132,6 +133,24 @@ namespace ks.fiks.io.arkivsystem.sample.Handlers
             }
             validationResult = null;
             return string.Empty;
+        }
+
+        protected Arkivmelding TryGetLagretArkivmelding(MottattMeldingArgs mottatt)
+        {
+            
+            // Er det en testSession fra integrasjonstester? 
+            if (mottatt.Melding.Headere.TryGetValue(ArkivSimulator.TestSessionIdHeader, out var testSessionId))
+            {
+                return ArkivSimulator._arkivmeldingCache[testSessionId];
+            }
+
+            // Er det test fra protokoll-validator?
+            if (mottatt.Melding.Headere.TryGetValue(ArkivSimulator.ValidatorTestNameHeader, out var testName)) 
+            {
+                return ArkivSimulator._arkivmeldingProtokollValidatorStorage[testName];
+            }
+
+            return null;
         }
     }
 }

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/Handlers/JournalpostHentHandler.cs
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/Handlers/JournalpostHentHandler.cs
@@ -56,17 +56,13 @@ namespace ks.fiks.io.arkivsystem.sample.Handlers
             }
 
             // Hent arkivmelding fra "cache" hvis det er en testSessionId i headere
-            Arkivmelding arkivmeldingLagret = null;
-            if (mottatt.Melding.Headere.TryGetValue(ArkivSimulator.TestSessionIdHeader, out var testSessionId))
-            {
-                ArkivSimulator._arkivmeldingCache.TryGetValue(testSessionId, out arkivmeldingLagret);
-            }
+            var lagretArkivmelding = TryGetLagretArkivmelding(mottatt);
 
             return new Melding
             {
-                ResultatMelding = arkivmeldingLagret == null
+                ResultatMelding = lagretArkivmelding == null
                     ? JournalpostHentGenerator.Create(hentMelding)
-                    : JournalpostHentGenerator.Create(hentMelding, JournalpostHentGenerator.CreateHentJournalpostFraArkivmeldingJournalpost((Journalpost) arkivmeldingLagret.Registrering[0])),
+                    : JournalpostHentGenerator.Create(hentMelding, JournalpostHentGenerator.CreateHentJournalpostFraArkivmeldingJournalpost((Journalpost) lagretArkivmelding.Registrering[0])),
                 FileName = "resultat.xml",
                 MeldingsType = FiksArkivV1Meldingtype.JournalpostHentResultat
             };

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/Handlers/JournalpostHentHandler.cs
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/Handlers/JournalpostHentHandler.cs
@@ -56,17 +56,17 @@ namespace ks.fiks.io.arkivsystem.sample.Handlers
             }
 
             // Hent arkivmelding fra "cache" hvis det er en testSessionId i headere
-            Arkivmelding arkivmelding = null;
+            Arkivmelding arkivmeldingLagret = null;
             if (mottatt.Melding.Headere.TryGetValue(ArkivSimulator.TestSessionIdHeader, out var testSessionId))
             {
-                ArkivSimulator._arkivmeldingCache.TryGetValue(testSessionId, out arkivmelding);
+                ArkivSimulator._arkivmeldingCache.TryGetValue(testSessionId, out arkivmeldingLagret);
             }
 
             return new Melding
             {
-                ResultatMelding = arkivmelding == null
+                ResultatMelding = arkivmeldingLagret == null
                     ? JournalpostHentGenerator.Create(hentMelding)
-                    : JournalpostHentGenerator.Create(hentMelding, JournalpostHentGenerator.CreateHentJournalpostArkivmeldingJournalpost((Journalpost) arkivmelding.Registrering[0])),
+                    : JournalpostHentGenerator.Create(hentMelding, JournalpostHentGenerator.CreateHentJournalpostFraArkivmeldingJournalpost((Journalpost) arkivmeldingLagret.Registrering[0])),
                 FileName = "resultat.xml",
                 MeldingsType = FiksArkivV1Meldingtype.JournalpostHentResultat
             };

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/Handlers/MappeHentHandler.cs
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/Handlers/MappeHentHandler.cs
@@ -56,14 +56,9 @@ namespace ks.fiks.io.arkivsystem.sample.Handlers
                 };
             }
 
-            // Hent arkivmelding fra "cache" hvis det er en testSessionId i headere
-            Arkivmelding arkivmelding = null;
-            if (mottatt.Melding.Headere.TryGetValue(ArkivSimulator.TestSessionIdHeader, out var testSessionId))
-            {
-                ArkivSimulator._arkivmeldingCache.TryGetValue(testSessionId, out arkivmelding);
-            }
+            var lagretArkivmelding = TryGetLagretArkivmelding(mottatt);
 
-            if (arkivmelding != null && arkivmelding.Mappe.Count <= 0)
+            if (lagretArkivmelding != null && lagretArkivmelding.Mappe.Count <= 0)
             {
                 return new Melding
                 {
@@ -75,9 +70,9 @@ namespace ks.fiks.io.arkivsystem.sample.Handlers
 
             return new Melding
             {
-                ResultatMelding = arkivmelding == null
+                ResultatMelding = lagretArkivmelding == null
                     ? MappeHentGenerator.Create(hentMelding)
-                    : MappeHentGenerator.CreateFromCache(hentMelding, arkivmelding),
+                    : MappeHentGenerator.CreateFromCache(hentMelding, lagretArkivmelding),
                 FileName = "resultat.xml",
                 MeldingsType = FiksArkivV1Meldingtype.MappeHentResultat
             };

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/Handlers/MappeHentHandler.cs
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/Handlers/MappeHentHandler.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Xml.Schema;
+using System.Xml.Serialization;
+using KS.Fiks.Arkiv.Models.V1.Arkivering.Arkivmelding;
+using KS.Fiks.Arkiv.Models.V1.Innsyn.Hent.Journalpost;
+using KS.Fiks.Arkiv.Models.V1.Innsyn.Hent.Mappe;
+using KS.Fiks.Arkiv.Models.V1.Meldingstyper;
+using ks.fiks.io.arkivsystem.sample.Generators;
+using ks.fiks.io.arkivsystem.sample.Models;
+using KS.Fiks.IO.Client.Models;
+using KS.Fiks.IO.Client.Models.Feilmelding;
+using Serilog;
+
+namespace ks.fiks.io.arkivsystem.sample.Handlers
+{
+    public class MappeHentHandler : BaseHandler
+    {
+        private static readonly ILogger Log = Serilog.Log.ForContext(MethodBase.GetCurrentMethod()?.DeclaringType);
+        
+        private MappeHent GetPayload(MottattMeldingArgs mottatt, XmlSchemaSet xmlSchemaSet,
+            out bool xmlValidationErrorOccured, out List<List<string>> validationResult)
+        {
+            if (mottatt.Melding.HasPayload)
+            {
+                var text = GetPayloadAsString(mottatt, xmlSchemaSet, out xmlValidationErrorOccured,
+                    out validationResult);
+                Log.Information("Parsing mappeHent: {Xml}", text);
+                if (string.IsNullOrEmpty(text))
+                {
+                    Log.Error("Tom mappeHent? Xml: {Xml}", text);
+                }
+
+                using var textReader = (TextReader)new StringReader(text);
+                return(MappeHent) new XmlSerializer(typeof(MappeHent)).Deserialize(textReader);
+            }
+
+            xmlValidationErrorOccured = false;
+            validationResult = null;
+            return null;
+        }
+
+        public Melding HandleMelding(MottattMeldingArgs mottatt)
+        {
+            var hentMelding = GetPayload(mottatt, XmlSchemaSet,
+                out var xmlValidationErrorOccured, out var validationResult);
+
+            if (xmlValidationErrorOccured)
+            {
+                return new Melding
+                {
+                    ResultatMelding = FeilmeldingGenerator.CreateUgyldigforespoerselMelding(validationResult),
+                    FileName = "payload.json",
+                    MeldingsType = FeilmeldingMeldingTypeV1.Ugyldigforespørsel,
+                };
+            }
+
+            // Hent arkivmelding fra "cache" hvis det er en testSessionId i headere
+            Arkivmelding arkivmelding = null;
+            if (mottatt.Melding.Headere.TryGetValue(ArkivSimulator.TestSessionIdHeader, out var testSessionId))
+            {
+                ArkivSimulator._arkivmeldingCache.TryGetValue(testSessionId, out arkivmelding);
+            }
+
+            if (arkivmelding != null && arkivmelding.Mappe.Count <= 0)
+            {
+                return new Melding
+                {
+                    ResultatMelding = "Kunne ikke finne noen mappe som tilsvarer det som er etterspurt i hentmelding",
+                    FileName = "payload.json",
+                    MeldingsType = FeilmeldingMeldingTypeV1.Ugyldigforespørsel,
+                };
+            }
+
+            return new Melding
+            {
+                ResultatMelding = arkivmelding == null
+                    ? MappeHentGenerator.Create(hentMelding)
+                    : MappeHentGenerator.CreateFromCache(hentMelding, arkivmelding),
+                FileName = "resultat.xml",
+                MeldingsType = FiksArkivV1Meldingtype.MappeHentResultat
+            };
+        }
+    }
+}

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/Xml/HentJournalpostN1/arkivmelding.xml
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/Xml/HentJournalpostN1/arkivmelding.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<arkivmelding xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://www.arkivverket.no/standarder/noark5/arkivmelding/v2">
+  <system>Fiks arkiv simulator</system>
+  <meldingId>ccf92bd1-d23c-4bba-9df8-a236c88c2844</meldingId>
+  <tidspunkt>0001-01-01T00:00:00</tidspunkt>
+  <antallFiler>1</antallFiler>
+  <registrering xsi:type="journalpost">
+    <opprettetAv>En brukerid</opprettetAv>
+    <arkivertAv>En brukerid</arkivertAv>
+    <referanseForelderMappe label="">c43e18dc-0224-4fac-9f80-01709f906b3d</referanseForelderMappe>
+    <dokumentbeskrivelse>
+      <dokumenttype>
+        <kode xmlns="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2">SØKNAD</kode>
+      </dokumenttype>
+      <dokumentstatus>
+        <kode xmlns="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2">F</kode>
+      </dokumentstatus>
+      <tittel>Rekvisisjon av oppmålingsforretning</tittel>
+      <tilknyttetRegistreringSom>
+        <kode xmlns="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2">H</kode>
+      </tilknyttetRegistreringSom>
+      <dokumentobjekt>
+        <versjonsnummer>1</versjonsnummer>
+        <variantformat>
+          <kode xmlns="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2">P</kode>
+        </variantformat>
+        <format>
+          <kode xmlns="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2">PDF</kode>
+        </format>
+        <filnavn>rekvisjon.pdf</filnavn>
+        <referanseDokumentfil>rekvisisjon.pdf</referanseDokumentfil>
+      </dokumentobjekt>
+    </dokumentbeskrivelse>
+    <tittel>Internt notat</tittel>
+    <korrespondansepart>
+      <korrespondanseparttype>
+        <kode xmlns="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2">IM</kode>
+      </korrespondanseparttype>
+      <korrespondansepartNavn>Oppmålingsetaten</korrespondansepartNavn>
+      <administrativEnhet>Oppmålingsetaten</administrativEnhet>
+      <saksbehandler>Ingrid Mottaker</saksbehandler>
+    </korrespondansepart>
+    <referanseEksternNoekkel>
+      <fagsystem xmlns="http://www.arkivverket.no/standarder/noark5/arkivstruktur">Fiks protokoll validator</fagsystem>
+      <noekkel xmlns="http://www.arkivverket.no/standarder/noark5/arkivstruktur">54834a29-517f-41a5-b562-0a5de5fcd27b</noekkel>
+    </referanseEksternNoekkel>
+    <journalposttype>
+      <kode xmlns="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2">X</kode>
+    </journalposttype>
+    <journalstatus>
+      <kode xmlns="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2">F</kode>
+    </journalstatus>
+  </registrering>
+</arkivmelding>

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/Xml/OppdaterMappeSaksansvarligN1/arkivmelding.xml
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/Xml/OppdaterMappeSaksansvarligN1/arkivmelding.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<arkivmelding xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://www.arkivverket.no/standarder/noark5/arkivmelding/v2">
+    <system>Fagsystem X</system>
+    <meldingId>af8f08cc-9a9d-40ff-99e8-c3459170c3c9</meldingId>
+    <tidspunkt>0001-01-01T00:00:00</tidspunkt>
+    <antallFiler>1</antallFiler>
+    <mappe xsi:type="saksmappe">
+        <tittel>En ny saksmappe fra integrasjonstest</tittel>
+        <referanseEksternNoekkel>
+            <fagsystem xmlns="http://www.arkivverket.no/standarder/noark5/arkivstruktur">Fiks protokoll validator</fagsystem>
+            <noekkel xmlns="http://www.arkivverket.no/standarder/noark5/arkivstruktur">ca3ce092-0bfa-46bb-ad18-b00a340cdd8c</noekkel>
+        </referanseEksternNoekkel>
+        <registrering xsi:type="journalpost">
+            <opprettetAv>En brukerid</opprettetAv>
+            <arkivertAv>En brukerid</arkivertAv>
+            <referanseForelderMappe label="">a8ab6c95-9f90-41be-a408-f6b7d65345e4</referanseForelderMappe>
+            <dokumentbeskrivelse>
+                <dokumenttype>
+                    <kode xmlns="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2">SØKNAD</kode>
+                </dokumenttype>
+                <dokumentstatus>
+                    <kode xmlns="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2">F</kode>
+                </dokumentstatus>
+                <tittel>Rekvisisjon av oppmålingsforretning</tittel>
+                <tilknyttetRegistreringSom>
+                    <kode xmlns="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2">H</kode>
+                </tilknyttetRegistreringSom>
+                <dokumentobjekt>
+                    <versjonsnummer>1</versjonsnummer>
+                    <variantformat>
+                        <kode xmlns="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2">P</kode>
+                    </variantformat>
+                    <format>
+                        <kode xmlns="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2">PDF</kode>
+                    </format>
+                    <filnavn>rekvisjon.pdf</filnavn>
+                    <referanseDokumentfil>rekvisisjon.pdf</referanseDokumentfil>
+                </dokumentobjekt>
+            </dokumentbeskrivelse>
+            <tittel>Internt notat</tittel>
+            <korrespondansepart>
+                <korrespondanseparttype>
+                    <kode xmlns="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2">IM</kode>
+                </korrespondanseparttype>
+                <korrespondansepartNavn>Oppmålingsetaten</korrespondansepartNavn>
+                <administrativEnhet>Oppmålingsetaten</administrativEnhet>
+                <saksbehandler>Ingrid Mottaker</saksbehandler>
+            </korrespondansepart>
+            <referanseEksternNoekkel>
+                <fagsystem xmlns="http://www.arkivverket.no/standarder/noark5/arkivstruktur">Fagsystem X</fagsystem>
+                <noekkel xmlns="http://www.arkivverket.no/standarder/noark5/arkivstruktur">
+                    6ea38455-48b1-4a94-9881-3cc2a065f04d
+                </noekkel>
+            </referanseEksternNoekkel>
+            <journalposttype>
+                <kode xmlns="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2">X</kode>
+            </journalposttype>
+            <journalstatus>
+                <kode xmlns="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2">F</kode>
+            </journalstatus>
+        </registrering>
+        <saksansvarlig>Sara Saksansvarlig</saksansvarlig>
+    </mappe>
+</arkivmelding>

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/ks.fiks.io.arkivsystem.sample.csproj
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/ks.fiks.io.arkivsystem.sample.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>10</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/ks.fiks.io.arkivsystem.sample.csproj
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/ks.fiks.io.arkivsystem.sample.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>10</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -45,11 +46,18 @@
 
   <ItemGroup>
     <Content Include="etc\fiks\ks-certs\KS-virksomhetssertifikat-auth.p12" CopyToOutputDirectory="Always" Condition="Exists('etc\fiks\ks-certs\KS-virksomhetssertifikat-auth.p12')" />
+    <Content Include="Xml\OppdaterMappeSaksansvarligN1\arkivmelding.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <None Remove="etc\fiks\fiks-io\privatekey.pem" />
     <Content Include="etc\fiks\fiks-io\development\privatekey.pem" Condition="Exists('etc\fiks\fiks-io\development\privatekey.pem')">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="etc\fiks\fiks-io\privatekey.pem" CopyToOutputDirectory="Always" Condition="Exists('etc\fiks\fiks-io\privatekey.pem')" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Remove="Xml\OppdaterMappeSaksansvarligN1\arkivmelding.xml" />
   </ItemGroup>
 
 </Project>

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/ks.fiks.io.arkivsystem.sample.csproj
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/ks.fiks.io.arkivsystem.sample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>10</LangVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Simulatoren skal nå kunne svare på oppdater mappe og saksmappe meldinger samt svare på testcases fra validatoren.
Dette gjøres ved at den har noen statiske arkivmeldinger som den ser at hører til en request (melding) fra validatoren. Da kan den hente innhold, oppdatere osv. basert på det den har lagret i den "statiske" arkivmeldingen. Dette skal funke ved siden av cachen som brukes av integrasjonstestene.