### PR TITLE
Oppdatert til siste fiks-io-client-dotnet

### DIFF
--- a/dotnet-source/ks.fiks.io.arkivintegrasjon.common/ks.fiks.io.arkivintegrasjon.common.csproj
+++ b/dotnet-source/ks.fiks.io.arkivintegrasjon.common/ks.fiks.io.arkivintegrasjon.common.csproj
@@ -8,7 +8,7 @@
     <ItemGroup>
       <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="0.0.7" />
       <PackageReference Include="KS.Fiks.ASiC-E" Version="1.0.3" />
-      <PackageReference Include="KS.Fiks.IO.Client" Version="1.2.6" />
+      <PackageReference Include="KS.Fiks.IO.Client" Version="1.2.7" />
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
       <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
     </ItemGroup>

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/ArkivSimulator.cs
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/ArkivSimulator.cs
@@ -7,7 +7,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Serialization;
 using KS.Fiks.Arkiv.Models.V1.Arkivering.Arkivmelding;
-using KS.Fiks.Arkiv.Models.V1.Arkivering.Arkivmeldingkvittering;
 using KS.Fiks.Arkiv.Models.V1.Meldingstyper;
 using ks.fiks.io.arkivintegrasjon.common.AppSettings;
 using ks.fiks.io.arkivintegrasjon.common.FiksIOClient;
@@ -18,7 +17,7 @@ using ks.fiks.io.arkivsystem.sample.Models;
 using ks.fiks.io.arkivsystem.sample.Storage;
 using KS.Fiks.IO.Client;
 using KS.Fiks.IO.Client.Models;
-using KS.Fiks.IO.Client.Models.Feilmelding;
+using KS.Fiks.Protokoller.V1.Models.Feilmelding;
 using Microsoft.Extensions.Hosting;
 using Newtonsoft.Json;
 using Serilog;
@@ -103,7 +102,7 @@ namespace ks.fiks.io.arkivsystem.sample
                     new StringPayload(
                         JsonConvert.SerializeObject(FeilmeldingGenerator.CreateUgyldigforespoerselMelding($"Ukjent meldingstype {mottatt.Melding.MeldingType} mottatt")),
                         "payload.json"));
-                mottatt.SvarSender.Svar(FeilmeldingMeldingTypeV1.Ugyldigforespørsel, payloads );
+                mottatt.SvarSender.Svar(FeilmeldingType.Ugyldigforespørsel, payloads );
             }
         }
 
@@ -130,11 +129,11 @@ namespace ks.fiks.io.arkivsystem.sample
                         FeilmeldingGenerator.CreateUgyldigforespoerselMelding(
                             $"Klarte ikke håndtere innkommende melding. Feilmelding: {e.Message}"),
                     FileName = "payload.json",
-                    MeldingsType = FeilmeldingMeldingTypeV1.Ugyldigforespørsel,
+                    MeldingsType = FeilmeldingType.Ugyldigforespørsel,
                 };
             }
 
-            if (melding.MeldingsType == FeilmeldingMeldingTypeV1.Ugyldigforespørsel)
+            if (melding.MeldingsType == FeilmeldingType.Ugyldigforespørsel)
             {
                 payloads.Add(new StringPayload(JsonConvert.SerializeObject(melding.ResultatMelding),
                     melding.FileName));
@@ -173,7 +172,7 @@ namespace ks.fiks.io.arkivsystem.sample
                 {
                     ResultatMelding = FeilmeldingGenerator.CreateUgyldigforespoerselMelding($"Klarte ikke håndtere innkommende melding. Feilmelding: {e.Message}"),
                     FileName = "payload.json",
-                    MeldingsType = FeilmeldingMeldingTypeV1.Ugyldigforespørsel,
+                    MeldingsType = FeilmeldingType.Ugyldigforespørsel,
                 });
             }
 
@@ -183,7 +182,7 @@ namespace ks.fiks.io.arkivsystem.sample
             {
                 if (melding.ResultatMelding != null)
                 {
-                    if (melding.MeldingsType == FeilmeldingMeldingTypeV1.Ugyldigforespørsel)
+                    if (melding.MeldingsType == FeilmeldingType.Ugyldigforespørsel)
                     {
                         payloads.Add(new StringPayload(JsonConvert.SerializeObject(melding.ResultatMelding),
                             melding.FileName));

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/Generators/ArkivmeldingKvitteringGenerator.cs
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/Generators/ArkivmeldingKvitteringGenerator.cs
@@ -1,44 +1,62 @@
 using System;
 using KS.Fiks.Arkiv.Models.V1.Arkivering.Arkivmelding;
 using KS.Fiks.Arkiv.Models.V1.Arkivering.Arkivmeldingkvittering;
-using KS.Fiks.Arkiv.Models.V1.Arkivstruktur;
-using KS.Fiks.Arkiv.Models.V1.Metadatakatalog;
 
 namespace ks.fiks.io.arkivsystem.sample.Generators
 {
     public class ArkivmeldingKvitteringGenerator
     {
-        public static SaksmappeKvittering CreateSaksmappeKvittering()
+        public static ArkivmeldingKvittering CreateArkivmeldingKvittering(Arkivmelding arkivmelding)
+        {
+            var kvittering = new ArkivmeldingKvittering
+            {
+                Tidspunkt = DateTime.Now
+            };
+            var isMappe = arkivmelding?.Mappe?.Count > 0;
+
+            if (isMappe)
+            {
+                foreach (var mappe in arkivmelding.Mappe)
+                {
+                    kvittering.MappeKvittering.Add(CreateSaksmappeKvittering(mappe));
+                }
+                
+            }
+            else
+            {
+                foreach (var registrering in arkivmelding.Registrering)
+                {
+                    kvittering.RegistreringKvittering.Add(CreateJournalpostKvittering(registrering));    
+                }
+                
+            }
+
+            return kvittering;
+        }
+        
+        private static SaksmappeKvittering CreateSaksmappeKvittering(Mappe mappe)
         {
             var mp = new SaksmappeKvittering
             {
-                SystemID = new SystemID
-                {
-                    Value = Guid.NewGuid().ToString()
-                },
+                SystemID = mappe.SystemID,
                 OpprettetDato = DateTime.Now,
                 Saksaar = DateTime.Now.Year.ToString(),
-                Sakssekvensnummer = new Random().Next().ToString()
+                Sakssekvensnummer = new Random().Next().ToString(),
+                ReferanseForeldermappe = mappe.ReferanseForeldermappe,
+                ReferanseEksternNoekkel = mappe.ReferanseEksternNoekkel,
             };
             return mp;
         }
 
-        public static JournalpostKvittering CreateJournalpostKvittering(Arkivmelding arkivmelding)
+        private static RegistreringKvittering CreateJournalpostKvittering(Registrering journalpost)
         {
             var jp = new JournalpostKvittering
             {
-                SystemID = new SystemID
-                {
-                    Value = Guid.NewGuid().ToString()
-                },
+                SystemID = journalpost.SystemID,
                 Journalaar = DateTime.Now.Year.ToString(),
                 Journalsekvensnummer = new Random().Next().ToString(),
                 Journalpostnummer = new Random().Next(1, 100).ToString(),
-                ReferanseEksternNoekkel = new EksternNoekkel()
-                {
-                    Fagsystem = arkivmelding.Registrering[0].ReferanseEksternNoekkel.Fagsystem,
-                    Noekkel = arkivmelding.Registrering[0].ReferanseEksternNoekkel.Noekkel
-                }
+                ReferanseEksternNoekkel = journalpost.ReferanseEksternNoekkel,
             };
             return jp;
         }

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/Generators/FeilmeldingGenerator.cs
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/Generators/FeilmeldingGenerator.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using KS.Fiks.IO.Client.Models.Feilmelding;
+using KS.Fiks.Protokoller.V1.Models.Feilmelding;
 
 namespace ks.fiks.io.arkivsystem.sample.Generators
 {

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/Generators/JournalpostHentResultatGenerator.cs
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/Generators/JournalpostHentResultatGenerator.cs
@@ -6,7 +6,7 @@ using KS.Fiks.Arkiv.Models.V1.Metadatakatalog;
 
 namespace ks.fiks.io.arkivsystem.sample.Generators
 {
-    public class JournalpostHentGenerator
+    public class JournalpostHentResultatGenerator
     {
         private const string DokumentbeskrivelseOpprettetAvDefault = "Foo";
         private const string JournalpostnummerDefault = "1";

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/Generators/MappeHentResultatGenerator.cs
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/Generators/MappeHentResultatGenerator.cs
@@ -7,7 +7,7 @@ using KS.Fiks.Arkiv.Models.V1.Metadatakatalog;
 
 namespace ks.fiks.io.arkivsystem.sample.Generators
 {
-    public class MappeHentGenerator
+    public class MappeHentResultatGenerator
     {
         public static MappeHentResultat Create(MappeHent mappeHent)
         {

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/Handlers/ArkivmeldingOppdaterHandler.cs
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/Handlers/ArkivmeldingOppdaterHandler.cs
@@ -10,7 +10,7 @@ using KS.Fiks.Arkiv.Models.V1.Meldingstyper;
 using ks.fiks.io.arkivsystem.sample.Generators;
 using ks.fiks.io.arkivsystem.sample.Models;
 using KS.Fiks.IO.Client.Models;
-using KS.Fiks.IO.Client.Models.Feilmelding;
+using KS.Fiks.Protokoller.V1.Models.Feilmelding;
 using Serilog;
 
 namespace ks.fiks.io.arkivsystem.sample.Handlers
@@ -32,7 +32,7 @@ namespace ks.fiks.io.arkivsystem.sample.Handlers
                         FeilmeldingGenerator.CreateUgyldigforespoerselMelding(
                             "ArkivmeldingOppdatering meldingen mangler innhold"),
                     FileName = "payload.json",
-                    MeldingsType = FeilmeldingMeldingTypeV1.Ugyldigforespørsel,
+                    MeldingsType = FeilmeldingType.Ugyldigforespørsel,
                 });
                 return meldinger;
             }
@@ -46,7 +46,7 @@ namespace ks.fiks.io.arkivsystem.sample.Handlers
                 {
                     ResultatMelding = FeilmeldingGenerator.CreateUgyldigforespoerselMelding(validationResult),
                     FileName = "payload.json",
-                    MeldingsType = FeilmeldingMeldingTypeV1.Ugyldigforespørsel,
+                    MeldingsType = FeilmeldingType.Ugyldigforespørsel,
                 });
                 return meldinger;
             }
@@ -79,7 +79,7 @@ namespace ks.fiks.io.arkivsystem.sample.Handlers
                             FeilmeldingGenerator.CreateServerFeilMelding(
                                 $"Noe gikk galt: {e.Message}"),
                         FileName = "payload.json",
-                        MeldingsType = FeilmeldingMeldingTypeV1.Serverfeil,
+                        MeldingsType = FeilmeldingType.Serverfeil,
                     });
                     return meldinger;
                 }
@@ -92,7 +92,7 @@ namespace ks.fiks.io.arkivsystem.sample.Handlers
                     ResultatMelding = FeilmeldingGenerator.CreateUgyldigforespoerselMelding(
                         "ArkivmeldingOppdatering ikke gyldig. Kunne ikke finne noe registrert i arkivet med gitt id"),
                     FileName = "payload.json",
-                    MeldingsType = FeilmeldingMeldingTypeV1.Ugyldigforespørsel,
+                    MeldingsType = FeilmeldingType.Ugyldigforespørsel,
                 });
                 return meldinger;
             }
@@ -142,7 +142,7 @@ namespace ks.fiks.io.arkivsystem.sample.Handlers
                             FeilmeldingGenerator.CreateUgyldigforespoerselMelding(
                                 "Mangler enten ReferanseEksternNoekkel eller SystemID for enten lagret mappe i 'arkivet' eller innkommende oppdatering. Kunne ikke matche forespørsel."),
                         FileName = "payload.json",
-                        MeldingsType = FeilmeldingMeldingTypeV1.Ugyldigforespørsel,
+                        MeldingsType = FeilmeldingType.Ugyldigforespørsel,
                     });
                 }
             }
@@ -169,7 +169,7 @@ namespace ks.fiks.io.arkivsystem.sample.Handlers
                 var found = false;
                 foreach (var registrering in lagretArkivmelding.Registrering)
                 {
-                    if (AreEqual(registrering, registreringOppdatering))
+                    if (AreEqual(registrering, registreringOppdatering.ReferanseEksternNoekkel, registreringOppdatering.SystemID))
                     {
                         if(registreringOppdatering.Tittel != null) { registrering.Tittel = registreringOppdatering.Tittel; }
                         if(registreringOppdatering.OffentligTittel != null) { registrering.OffentligTittel = registreringOppdatering.OffentligTittel; }
@@ -191,7 +191,7 @@ namespace ks.fiks.io.arkivsystem.sample.Handlers
                             FeilmeldingGenerator.CreateUgyldigforespoerselMelding(
                                 "Mangler enten ReferanseEksternNoekkel eller SystemID for enten lagret registrering i 'arkivet' eller innkommende oppdatering. Kunne ikke matche forespørsel."),
                         FileName = "payload.json",
-                        MeldingsType = FeilmeldingMeldingTypeV1.Ugyldigforespørsel,
+                        MeldingsType = FeilmeldingType.Ugyldigforespørsel,
                     });
                 }
             }
@@ -205,50 +205,6 @@ namespace ks.fiks.io.arkivsystem.sample.Handlers
                 });
             }
             return meldinger;
-        }
-
-        private static bool AreEqual(Registrering lagretRegistrering, RegistreringOppdatering registreringOppdatering)
-        {
-            if (registreringOppdatering.ReferanseEksternNoekkel != null && lagretRegistrering.ReferanseEksternNoekkel != null)
-            {
-                if (lagretRegistrering.ReferanseEksternNoekkel.Fagsystem ==
-                    registreringOppdatering.ReferanseEksternNoekkel.Fagsystem &&
-                    lagretRegistrering.ReferanseEksternNoekkel.Noekkel ==
-                    registreringOppdatering.ReferanseEksternNoekkel.Noekkel)
-                {
-                    return true;
-                }
-            }
-            else if (registreringOppdatering.SystemID != null && lagretRegistrering.SystemID != null)
-            {
-                if (lagretRegistrering.SystemID == registreringOppdatering.SystemID)
-                {
-                    return true;
-                }
-            }
-            return false;
-        }
-        
-        private static bool AreEqual(Mappe lagretMappe, MappeOppdatering mappeOppdatering)
-        {
-            if (mappeOppdatering.ReferanseEksternNoekkel != null && lagretMappe.ReferanseEksternNoekkel != null)
-            {
-                if (lagretMappe.ReferanseEksternNoekkel.Fagsystem ==
-                    mappeOppdatering.ReferanseEksternNoekkel.Fagsystem &&
-                    lagretMappe.ReferanseEksternNoekkel.Noekkel ==
-                    mappeOppdatering.ReferanseEksternNoekkel.Noekkel)
-                {
-                    return true;
-                }
-            }
-            else if (mappeOppdatering.SystemID != null && lagretMappe.SystemID != null)
-            {
-                if (lagretMappe.SystemID == mappeOppdatering.SystemID)
-                {
-                    return true;
-                }
-            }
-            return false;
         }
 
         private ArkivmeldingOppdatering GetPayload(MottattMeldingArgs mottatt, XmlSchemaSet xmlSchemaSet,

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/Handlers/BaseHandler.cs
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/Handlers/BaseHandler.cs
@@ -25,8 +25,7 @@ namespace ks.fiks.io.arkivsystem.sample.Handlers
         protected BaseHandler()
         {
             XmlSchemaSet = new XmlSchemaSet();
-            var arkivModelsAssembly = AppDomain.CurrentDomain.GetAssemblies()
-                .SingleOrDefault(assembly => assembly.GetName().Name == "KS.Fiks.Arkiv.Models.V1");
+            var arkivModelsAssembly = Assembly.Load("KS.Fiks.Arkiv.Models.V1");
             
             using (var schemaStream =
                 arkivModelsAssembly.GetManifestResourceStream("KS.Fiks.Arkiv.Models.V1.Schema.V1.arkivmelding.xsd"))

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/Handlers/MappeHentHandler.cs
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/Handlers/MappeHentHandler.cs
@@ -3,14 +3,12 @@ using System.IO;
 using System.Reflection;
 using System.Xml.Schema;
 using System.Xml.Serialization;
-using KS.Fiks.Arkiv.Models.V1.Arkivering.Arkivmelding;
-using KS.Fiks.Arkiv.Models.V1.Innsyn.Hent.Journalpost;
 using KS.Fiks.Arkiv.Models.V1.Innsyn.Hent.Mappe;
 using KS.Fiks.Arkiv.Models.V1.Meldingstyper;
 using ks.fiks.io.arkivsystem.sample.Generators;
 using ks.fiks.io.arkivsystem.sample.Models;
 using KS.Fiks.IO.Client.Models;
-using KS.Fiks.IO.Client.Models.Feilmelding;
+using KS.Fiks.Protokoller.V1.Models.Feilmelding;
 using Serilog;
 
 namespace ks.fiks.io.arkivsystem.sample.Handlers
@@ -52,10 +50,11 @@ namespace ks.fiks.io.arkivsystem.sample.Handlers
                 {
                     ResultatMelding = FeilmeldingGenerator.CreateUgyldigforespoerselMelding(validationResult),
                     FileName = "payload.json",
-                    MeldingsType = FeilmeldingMeldingTypeV1.Ugyldigforespørsel,
+                    MeldingsType = FeilmeldingType.Ugyldigforespørsel,
                 };
             }
 
+            // Forsøk å hente arkivmelding fra lokal lagring
             var lagretArkivmelding = TryGetLagretArkivmelding(mottatt);
 
             if (lagretArkivmelding != null && lagretArkivmelding.Mappe.Count <= 0)
@@ -64,15 +63,15 @@ namespace ks.fiks.io.arkivsystem.sample.Handlers
                 {
                     ResultatMelding = "Kunne ikke finne noen mappe som tilsvarer det som er etterspurt i hentmelding",
                     FileName = "payload.json",
-                    MeldingsType = FeilmeldingMeldingTypeV1.Ugyldigforespørsel,
+                    MeldingsType = FeilmeldingType.Ikkefunnet,
                 };
             }
 
             return new Melding
             {
                 ResultatMelding = lagretArkivmelding == null
-                    ? MappeHentGenerator.Create(hentMelding)
-                    : MappeHentGenerator.CreateFromCache(hentMelding, lagretArkivmelding),
+                    ? MappeHentResultatGenerator.Create(hentMelding)
+                    : MappeHentResultatGenerator.CreateFromCache(hentMelding, lagretArkivmelding),
                 FileName = "resultat.xml",
                 MeldingsType = FiksArkivV1Meldingtype.MappeHentResultat
             };

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/Handlers/SokHandler.cs
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/Handlers/SokHandler.cs
@@ -7,7 +7,7 @@ using KS.Fiks.Arkiv.Models.V1.Innsyn.Sok;
 using ks.fiks.io.arkivsystem.sample.Generators;
 using ks.fiks.io.arkivsystem.sample.Models;
 using KS.Fiks.IO.Client.Models;
-using KS.Fiks.IO.Client.Models.Feilmelding;
+using KS.Fiks.Protokoller.V1.Models.Feilmelding;
 using Serilog;
 
 namespace ks.fiks.io.arkivsystem.sample.Handlers
@@ -53,7 +53,7 @@ namespace ks.fiks.io.arkivsystem.sample.Handlers
                 {
                     ResultatMelding = FeilmeldingGenerator.CreateUgyldigforespoerselMelding(validationResult),
                     FileName = "payload.json",
-                    MeldingsType = FeilmeldingMeldingTypeV1.Ugyldigforespørsel,
+                    MeldingsType = FeilmeldingType.Ugyldigforespørsel,
                 };
             }
 

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/Xml/HentJournalpostN1/arkivmelding.xml
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/Xml/HentJournalpostN1/arkivmelding.xml
@@ -5,6 +5,7 @@
   <tidspunkt>0001-01-01T00:00:00</tidspunkt>
   <antallFiler>1</antallFiler>
   <registrering xsi:type="journalpost">
+    <systemID>6f358ced-036d-4c9b-b372-a2b7d83c5cc5</systemID>
     <opprettetAv>En brukerid</opprettetAv>
     <arkivertAv>En brukerid</arkivertAv>
     <referanseForelderMappe label="">c43e18dc-0224-4fac-9f80-01709f906b3d</referanseForelderMappe>

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/ks.fiks.io.arkivsystem.sample.csproj
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/ks.fiks.io.arkivsystem.sample.csproj
@@ -25,7 +25,8 @@
   <ItemGroup>
     <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="0.0.7" />
     <PackageReference Include="KS.Fiks.ASiC-E" Version="1.0.3" />
-    <PackageReference Include="KS.Fiks.IO.Client" Version="1.2.6" />
+    <PackageReference Include="KS.Fiks.IO.Client" Version="1.2.7" />
+    <PackageReference Include="KS.Fiks.Protokoller.V1" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />

--- a/dotnet-source/ks.fiks.io.fagsystem.arkiv.sample/ks.fiks.io.fagsystem.arkiv.sample.csproj
+++ b/dotnet-source/ks.fiks.io.fagsystem.arkiv.sample/ks.fiks.io.fagsystem.arkiv.sample.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="KS.Fiks.Arkiv.Forenklet.Arkivering.V1" Version="1.0.0" />
     <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="0.0.7" />
     <PackageReference Include="KS.Fiks.ASiC-E" Version="1.0.3" />
-    <PackageReference Include="KS.Fiks.IO.Client" Version="1.2.6" />
+    <PackageReference Include="KS.Fiks.IO.Client" Version="1.2.7" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />


### PR DESCRIPTION
Oppdatert koden med at den bruker Fiks-Protokoller i stedet for Fiks-IO-client-dotnet for feilmeldinger. Henter også fra statiske arkivmelding.xml filer for tester fra validator hvor det er unaturlig å lage de fra scratch. Det skal hentes en arkivmelding.xml bare.