### PR TITLE
Oppdatert til .net 6 og siste nuget pakker 

### DIFF
--- a/dotnet-source/ks.fiks.io.arkivintegrasjon.common/ks.fiks.io.arkivintegrasjon.common.csproj
+++ b/dotnet-source/ks.fiks.io.arkivintegrasjon.common/ks.fiks.io.arkivintegrasjon.common.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <VersionPrefix>1.0.18</VersionPrefix>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="0.0.9" />
+      <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="0.0.11" />
       <PackageReference Include="KS.Fiks.ASiC-E" Version="1.0.3" />
-      <PackageReference Include="KS.Fiks.IO.Client" Version="1.2.7" />
+      <PackageReference Include="KS.Fiks.IO.Client" Version="1.2.10" />
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
       <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
     </ItemGroup>

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/Dockerfile
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:3.1-alpine AS core-build-env
+FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS core-build-env
 WORKDIR /build-app
 
 # Copy csproj and build + publish code
@@ -10,7 +10,7 @@ RUN dotnet build --configuration Release ks.fiks.io.arkivsystem.sample/ks.fiks.i
 RUN dotnet publish --configuration Release ks.fiks.io.arkivsystem.sample/ks.fiks.io.arkivsystem.sample.csproj --no-build --output published-app
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:3.1
+FROM mcr.microsoft.com/dotnet/aspnet:6.0
 WORKDIR /app
 COPY --from=core-build-env /build-app/published-app .
 

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/Generators/ArkivmeldingGenerator.cs
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/Generators/ArkivmeldingGenerator.cs
@@ -1,4 +1,5 @@
 using System;
+using KS.Fiks.Arkiv.Models.V1.Arkivering.Arkivmelding;
 using KS.Fiks.Arkiv.Models.V1.Arkivstruktur;
 using KS.Fiks.Arkiv.Models.V1.Metadatakatalog;
 using Dokumentbeskrivelse = KS.Fiks.Arkiv.Models.V1.Arkivering.Arkivmelding.Dokumentbeskrivelse;
@@ -16,7 +17,10 @@ namespace ks.fiks.io.arkivsystem.sample.Generators
             {
                 OpprettetAv = "En brukerid",
                 ArkivertAv = "En brukerid",
-                ReferanseForelderMappe = new SystemID() { Label = "", Value = Guid.NewGuid().ToString() },
+                ReferanseForelderMappe = new ReferanseForelderMappe()
+                {
+                    SystemID = new SystemID() { Label = "", Value = Guid.NewGuid().ToString() }
+                },
                 ReferanseEksternNoekkel = new EksternNoekkel()
                 {
                     Fagsystem = "Fagsystem X",

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/Generators/ArkivmeldingKvitteringGenerator.cs
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/Generators/ArkivmeldingKvitteringGenerator.cs
@@ -42,7 +42,7 @@ namespace ks.fiks.io.arkivsystem.sample.Generators
                 OpprettetDato = DateTime.Now,
                 Saksaar = DateTime.Now.Year.ToString(),
                 Sakssekvensnummer = new Random().Next().ToString(),
-                ReferanseForeldermappe = mappe.ReferanseForeldermappe,
+                ReferanseForeldermappe = mappe.ReferanseForeldermappe.SystemID,
                 ReferanseEksternNoekkel = mappe.ReferanseEksternNoekkel,
             };
             return mp;

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/Generators/JournalpostHentResultatGenerator.cs
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/Generators/JournalpostHentResultatGenerator.cs
@@ -79,8 +79,8 @@ namespace ks.fiks.io.arkivsystem.sample.Generators
             {
                 jp.ReferanseForelderMappe = new SystemID()
                 {
-                    Label = arkivmeldingJournalpost.ReferanseForelderMappe.Label,
-                    Value = arkivmeldingJournalpost.ReferanseForelderMappe.Value
+                    Label = arkivmeldingJournalpost.ReferanseForelderMappe.SystemID.Label,
+                    Value = arkivmeldingJournalpost.ReferanseForelderMappe.SystemID.Value
                 };
             }
 

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/Generators/MappeHentResultatGenerator.cs
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/Generators/MappeHentResultatGenerator.cs
@@ -120,8 +120,8 @@ namespace ks.fiks.io.arkivsystem.sample.Generators
             {
                 mappe.ReferanseForeldermappe = new SystemID()
                 {
-                    Label = arkivmeldingMappe.ReferanseForeldermappe.Label,
-                    Value = arkivmeldingMappe.ReferanseForeldermappe.Value
+                    Label = arkivmeldingMappe.ReferanseForeldermappe.SystemID.Label,
+                    Value = arkivmeldingMappe.ReferanseForeldermappe.SystemID.Value
                 };
             }
 

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/Handlers/ArkivmeldingHandler.cs
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/Handlers/ArkivmeldingHandler.cs
@@ -91,7 +91,7 @@ namespace ks.fiks.io.arkivsystem.sample.Handlers
                             {
                                 foreach (var lagretMappe in lagretArkvivmelding.Mappe)
                                 {
-                                    if (lagretMappe.SystemID.Value == registrering.ReferanseForelderMappe.Value)
+                                    if (lagretMappe.SystemID.Value == registrering.ReferanseForelderMappe.SystemID.Value)
                                     {
                                         lagretMappe.Registrering.Add(registrering);
                                     }

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/ks.fiks.io.arkivsystem.sample.csproj
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/ks.fiks.io.arkivsystem.sample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -23,9 +23,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="0.0.9" />
+    <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="0.0.11" />
     <PackageReference Include="KS.Fiks.ASiC-E" Version="1.0.3" />
-    <PackageReference Include="KS.Fiks.IO.Client" Version="1.2.7" />
+    <PackageReference Include="KS.Fiks.IO.Client" Version="1.2.10" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />

--- a/dotnet-source/ks.fiks.io.fagsystem.arkiv.sample/Dockerfile
+++ b/dotnet-source/ks.fiks.io.fagsystem.arkiv.sample/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:3.1-alpine AS core-build-env
+FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS core-build-env
 WORKDIR /build-app
 
 # Copy csproj and build + publish code
@@ -10,7 +10,7 @@ RUN dotnet build --configuration Release ks.fiks.io.fagsystem.arkiv.sample/ks.fi
 RUN dotnet publish --configuration Release ks.fiks.io.fagsystem.arkiv.sample/ks.fiks.io.fagsystem.arkiv.sample.csproj --no-build --output published-app
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:3.1
+FROM mcr.microsoft.com/dotnet/aspnet:6.0
 WORKDIR /app
 COPY --from=core-build-env /build-app/published-app .
 

--- a/dotnet-source/ks.fiks.io.fagsystem.arkiv.sample/ks.fiks.io.fagsystem.arkiv.sample.csproj
+++ b/dotnet-source/ks.fiks.io.fagsystem.arkiv.sample/ks.fiks.io.fagsystem.arkiv.sample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -26,9 +26,9 @@
 
   <ItemGroup>
     <PackageReference Include="KS.Fiks.Arkiv.Forenklet.Arkivering.V1" Version="1.0.1" />
-    <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="0.0.9" />
+    <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="0.0.11" />
     <PackageReference Include="KS.Fiks.ASiC-E" Version="1.0.3" />
-    <PackageReference Include="KS.Fiks.IO.Client" Version="1.2.7" />
+    <PackageReference Include="KS.Fiks.IO.Client" Version="1.2.10" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />


### PR DESCRIPTION
Oppdatert til .net 6 samt oppdatert til nyeste versjon av våre pakker som medførte endringer i bygging av meldinger

Oppdateringen har også medført at det måtte endres litt i Jenkinsfile for bygging på Jenkins. Ser også at noen ting mtp bygging av meldinger nå ser rart ut. Dette gjelder ReferanseForeldermappe. Har løftet det til [issue](https://github.com/ks-no/fiks-arkiv/issues/77#issuecomment-1160114771) hvor det kan diskuteres videre.