### PR TITLE
Oppdatert i henhold til siste fiks-arkiv spec

### DIFF
--- a/dotnet-source/ks.fiks.io.arkivintegrasjon.common/ks.fiks.io.arkivintegrasjon.common.csproj
+++ b/dotnet-source/ks.fiks.io.arkivintegrasjon.common/ks.fiks.io.arkivintegrasjon.common.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="0.0.11" />
+      <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="0.0.12" />
       <PackageReference Include="KS.Fiks.ASiC-E" Version="1.0.3" />
       <PackageReference Include="KS.Fiks.IO.Client" Version="1.2.10" />
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/ArkivSimulator.cs
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/ArkivSimulator.cs
@@ -100,7 +100,7 @@ namespace ks.fiks.io.arkivsystem.sample
                 payloads.Add(
                     new StringPayload(
                         JsonConvert.SerializeObject(FeilmeldingGenerator.CreateUgyldigforespoerselMelding($"Ukjent meldingstype {mottatt.Melding.MeldingType} mottatt")),
-                        "payload.json"));
+                        "feilmelding.xml"));
                 mottatt.SvarSender.Svar(FiksArkivMeldingtype.Ugyldigforespørsel, payloads );
             }
         }
@@ -127,22 +127,13 @@ namespace ks.fiks.io.arkivsystem.sample
                     ResultatMelding =
                         FeilmeldingGenerator.CreateUgyldigforespoerselMelding(
                             $"Klarte ikke håndtere innkommende melding. Feilmelding: {e.Message}"),
-                    FileName = "payload.json",
+                    FileName = "feilmelding.xml",
                     MeldingsType = FiksArkivMeldingtype.Ugyldigforespørsel,
                 };
             }
-
-            // Json format
-            if (melding.MeldingsType == FiksArkivMeldingtype.Ugyldigforespørsel || melding.MeldingsType == FiksArkivMeldingtype.Ikkefunnet || melding.MeldingsType == FiksArkivMeldingtype.Serverfeil)
-            {
-                payloads.Add(new StringPayload(JsonConvert.SerializeObject(melding.ResultatMelding),
+ 
+            payloads.Add(new StringPayload(ArkivmeldingSerializeHelper.Serialize(melding.ResultatMelding),
                     melding.FileName));
-            }
-            else // Xml format
-            {
-                payloads.Add(new StringPayload(ArkivmeldingSerializeHelper.Serialize(melding.ResultatMelding),
-                    melding.FileName));
-            }
 
             mottatt.SvarSender.Ack(); // Ack message to remove it from the queue
 
@@ -171,7 +162,7 @@ namespace ks.fiks.io.arkivsystem.sample
                 meldinger.Add(new Melding
                 {
                     ResultatMelding = FeilmeldingGenerator.CreateUgyldigforespoerselMelding($"Klarte ikke håndtere innkommende melding. Feilmelding: {e.Message}"),
-                    FileName = "payload.json",
+                    FileName = "feilmelding.xml",
                     MeldingsType = FiksArkivMeldingtype.Ugyldigforespørsel,
                 });
             }
@@ -182,16 +173,9 @@ namespace ks.fiks.io.arkivsystem.sample
             {
                 if (melding.ResultatMelding != null)
                 {
-                    if (melding.MeldingsType == FiksArkivMeldingtype.Ugyldigforespørsel)
-                    {
-                        payloads.Add(new StringPayload(JsonConvert.SerializeObject(melding.ResultatMelding),
-                            melding.FileName));
-                    }
-                    else
-                    {
-                        payloads.Add(new StringPayload(ArkivmeldingSerializeHelper.Serialize(melding.ResultatMelding),
-                            melding.FileName));
-                    }
+              
+                    payloads.Add(new StringPayload(ArkivmeldingSerializeHelper.Serialize(melding.ResultatMelding), melding.FileName));
+              
                 }
 
                 var sendtMelding = mottatt.SvarSender.Svar(melding.MeldingsType, payloads).Result;

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/Generators/ArkivmeldingKvitteringGenerator.cs
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/Generators/ArkivmeldingKvitteringGenerator.cs
@@ -42,7 +42,7 @@ namespace ks.fiks.io.arkivsystem.sample.Generators
                 OpprettetDato = DateTime.Now,
                 Saksaar = DateTime.Now.Year.ToString(),
                 Sakssekvensnummer = new Random().Next().ToString(),
-                ReferanseForeldermappe = mappe.ReferanseForeldermappe.SystemID,
+                ReferanseForeldermappe = mappe.ReferanseForeldermappe?.SystemID,
                 ReferanseEksternNoekkel = mappe.ReferanseEksternNoekkel,
             };
             return mp;

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/Handlers/ArkivmeldingHandler.cs
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/Handlers/ArkivmeldingHandler.cs
@@ -54,7 +54,7 @@ namespace ks.fiks.io.arkivsystem.sample.Handlers
                     meldinger.Add(new Melding
                     {
                         ResultatMelding = FeilmeldingGenerator.CreateUgyldigforespoerselMelding(validationResult),
-                        FileName = "payload.json",
+                        FileName = "feilmelding.xml",
                         MeldingsType = FiksArkivMeldingtype.Ugyldigforespørsel,
                     });
                     return meldinger;
@@ -66,7 +66,7 @@ namespace ks.fiks.io.arkivsystem.sample.Handlers
                 {
                     ResultatMelding =
                         FeilmeldingGenerator.CreateUgyldigforespoerselMelding("Arkivmelding meldingen mangler innhold"),
-                    FileName = "payload.json",
+                    FileName = "feilmelding.xml",
                     MeldingsType = FiksArkivMeldingtype.Ugyldigforespørsel,
                 });
                 return meldinger;

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/Handlers/ArkivmeldingOppdaterHandler.cs
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/Handlers/ArkivmeldingOppdaterHandler.cs
@@ -30,7 +30,7 @@ namespace ks.fiks.io.arkivsystem.sample.Handlers
                     ResultatMelding =
                         FeilmeldingGenerator.CreateUgyldigforespoerselMelding(
                             "ArkivmeldingOppdatering meldingen mangler innhold"),
-                    FileName = "payload.json",
+                    FileName = "feilmelding.xml",
                     MeldingsType = FiksArkivMeldingtype.Ugyldigforespørsel,
                 });
                 return meldinger;
@@ -44,7 +44,7 @@ namespace ks.fiks.io.arkivsystem.sample.Handlers
                 meldinger.Add(new Melding
                 {
                     ResultatMelding = FeilmeldingGenerator.CreateUgyldigforespoerselMelding(validationResult),
-                    FileName = "payload.json",
+                    FileName = "feilmelding.xml",
                     MeldingsType = FiksArkivMeldingtype.Ugyldigforespørsel,
                 });
                 return meldinger;
@@ -77,7 +77,7 @@ namespace ks.fiks.io.arkivsystem.sample.Handlers
                         ResultatMelding =
                             FeilmeldingGenerator.CreateServerFeilMelding(
                                 $"Noe gikk galt: {e.Message}"),
-                        FileName = "payload.json",
+                        FileName = "feilmelding.xml",
                         MeldingsType = FiksArkivMeldingtype.Serverfeil,
                     });
                     return meldinger;
@@ -90,7 +90,7 @@ namespace ks.fiks.io.arkivsystem.sample.Handlers
                 {
                     ResultatMelding = FeilmeldingGenerator.CreateUgyldigforespoerselMelding(
                         "ArkivmeldingOppdatering ikke gyldig. Kunne ikke finne noe registrert i arkivet med gitt id"),
-                    FileName = "payload.json",
+                    FileName = "feilmelding.xml",
                     MeldingsType = FiksArkivMeldingtype.Ugyldigforespørsel,
                 });
                 return meldinger;
@@ -140,7 +140,7 @@ namespace ks.fiks.io.arkivsystem.sample.Handlers
                         ResultatMelding =
                             FeilmeldingGenerator.CreateUgyldigforespoerselMelding(
                                 "Mangler enten ReferanseEksternNoekkel eller SystemID for enten lagret mappe i 'arkivet' eller innkommende oppdatering. Kunne ikke matche forespørsel."),
-                        FileName = "payload.json",
+                        FileName = "feilmelding.xml",
                         MeldingsType = FiksArkivMeldingtype.Ugyldigforespørsel,
                     });
                 }
@@ -189,7 +189,7 @@ namespace ks.fiks.io.arkivsystem.sample.Handlers
                         ResultatMelding =
                             FeilmeldingGenerator.CreateUgyldigforespoerselMelding(
                                 "Mangler enten ReferanseEksternNoekkel eller SystemID for enten lagret registrering i 'arkivet' eller innkommende oppdatering. Kunne ikke matche forespørsel."),
-                        FileName = "payload.json",
+                        FileName = "feilmelding.xml",
                         MeldingsType = FiksArkivMeldingtype.Ugyldigforespørsel,
                     });
                 }

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/Handlers/JournalpostHentHandler.cs
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/Handlers/JournalpostHentHandler.cs
@@ -100,7 +100,7 @@ namespace ks.fiks.io.arkivsystem.sample.Handlers
                 return new Melding
                 {
                     ResultatMelding = FeilmeldingGenerator.CreateUgyldigforespoerselMelding(validationResult),
-                    FileName = "payload.json",
+                    FileName = "feilmelding.xml",
                     MeldingsType = FiksArkivMeldingtype.Ugyldigforespørsel,
                 };
             }
@@ -113,7 +113,7 @@ namespace ks.fiks.io.arkivsystem.sample.Handlers
                 return new Melding
                 {
                     ResultatMelding = FeilmeldingGenerator.CreateIkkefunnetMelding("Kunne ikke finne noen journalpost som tilsvarer det som er etterspurt i hentmelding"),
-                    FileName = "payload.json",
+                    FileName = "feilmelding.xml",
                     MeldingsType = FiksArkivMeldingtype.Ikkefunnet,
                 };
             }

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/Handlers/MappeHentHandler.cs
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/Handlers/MappeHentHandler.cs
@@ -49,7 +49,7 @@ namespace ks.fiks.io.arkivsystem.sample.Handlers
                 return new Melding
                 {
                     ResultatMelding = FeilmeldingGenerator.CreateUgyldigforespoerselMelding(validationResult),
-                    FileName = "payload.json",
+                    FileName = "feilmelding.xml",
                     MeldingsType = FiksArkivMeldingtype.Ugyldigforespørsel,
                 };
             }
@@ -62,7 +62,7 @@ namespace ks.fiks.io.arkivsystem.sample.Handlers
                 return new Melding
                 {
                     ResultatMelding = FeilmeldingGenerator.CreateIkkefunnetMelding("Kunne ikke finne noen mappe som tilsvarer det som er etterspurt i hentmelding"),
-                    FileName = "payload.json",
+                    FileName = "feilmelding.xml",
                     MeldingsType = FiksArkivMeldingtype.Ikkefunnet,
                 };
             }

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/Handlers/SokHandler.cs
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/Handlers/SokHandler.cs
@@ -52,7 +52,7 @@ namespace ks.fiks.io.arkivsystem.sample.Handlers
                 return new Melding
                 {
                     ResultatMelding = FeilmeldingGenerator.CreateUgyldigforespoerselMelding(validationResult),
-                    FileName = "payload.json",
+                    FileName = "feilmelding.xml",
                     MeldingsType = FiksArkivMeldingtype.Ugyldigforespørsel,
                 };
             }

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/Xml/HentJournalpostN1/arkivmelding.xml
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/Xml/HentJournalpostN1/arkivmelding.xml
@@ -8,7 +8,9 @@
     <systemID>6f358ced-036d-4c9b-b372-a2b7d83c5cc5</systemID>
     <opprettetAv>En brukerid</opprettetAv>
     <arkivertAv>En brukerid</arkivertAv>
-    <referanseForelderMappe label="">c43e18dc-0224-4fac-9f80-01709f906b3d</referanseForelderMappe>
+    <referanseForelderMappe>
+      <systemID>c43e18dc-0224-4fac-9f80-01709f906b3d</systemID>
+    </referanseForelderMappe>
     <dokumentbeskrivelse>
       <dokumenttype>
         <kode xmlns="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2">SØKNAD</kode>

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/Xml/HentJournalpostN2/arkivmelding.xml
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/Xml/HentJournalpostN2/arkivmelding.xml
@@ -8,7 +8,9 @@
     <systemID>6f358ced-036d-4c9b-b372-a2b7d83c5cc5</systemID>
     <opprettetAv>En brukerid</opprettetAv>
     <arkivertAv>En brukerid</arkivertAv>
-    <referanseForelderMappe label="">c43e18dc-0224-4fac-9f80-01709f906b3d</referanseForelderMappe>
+    <referanseForelderMappe>
+      <systemID>c43e18dc-0224-4fac-9f80-01709f906b3d</systemID>
+    </referanseForelderMappe>
     <dokumentbeskrivelse>
       <dokumenttype>
         <kode xmlns="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2">SØKNAD</kode>

--- a/dotnet-source/ks.fiks.io.arkivsystem.sample/ks.fiks.io.arkivsystem.sample.csproj
+++ b/dotnet-source/ks.fiks.io.arkivsystem.sample/ks.fiks.io.arkivsystem.sample.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="0.0.11" />
+    <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="0.0.12" />
     <PackageReference Include="KS.Fiks.ASiC-E" Version="1.0.3" />
     <PackageReference Include="KS.Fiks.IO.Client" Version="1.2.10" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />

--- a/dotnet-source/ks.fiks.io.fagsystem.arkiv.sample/ks.fiks.io.fagsystem.arkiv.sample.csproj
+++ b/dotnet-source/ks.fiks.io.fagsystem.arkiv.sample/ks.fiks.io.fagsystem.arkiv.sample.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="KS.Fiks.Arkiv.Forenklet.Arkivering.V1" Version="1.0.1" />
-    <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="0.0.11" />
+    <PackageReference Include="KS.Fiks.Arkiv.Models.V1" Version="0.0.12" />
     <PackageReference Include="KS.Fiks.ASiC-E" Version="1.0.3" />
     <PackageReference Include="KS.Fiks.IO.Client" Version="1.2.10" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />


### PR DESCRIPTION
Oppdatert simulator slik at den leverer i henhold til siste endringer i fiks-arkiv-specification

Det har vært endringer i feilmeldinger, filtyper for disse og den nye ReferanseForeldermappe i fiks-arkiv spesifikasjonen som gjør at det måtte gjøres endringer her i eksempelkoden og simulatoren.